### PR TITLE
corrected a bug in get_desktop_environment(), a comma was missing

### DIFF
--- a/src/comun.py
+++ b/src/comun.py
@@ -88,7 +88,7 @@ def get_desktop_environment():
     desktop_session = os.environ.get("DESKTOP_SESSION")
     if desktop_session is not None:
         desktop_session = desktop_session.lower()
-        if desktop_session in ["gnome", "unity", "cinnamon"
+        if desktop_session in ["gnome", "unity", "cinnamon",
                                "budgie-desktop", "xfce4", "lxde", "fluxbox",
                                "blackbox", "openbox", "icewm", "jwm",
                                "afterstep", "trinity", "kde"]:


### PR DESCRIPTION
In the file comun.py, in the function get_desktop_environment(), a comma was missing in line 91, after "cinnamon" string. 

This made that the app didn't change the wallpaper in cinnamon desktops.